### PR TITLE
update term "Ground Floor Height" to "Finished floor height"

### DIFF
--- a/src/delftdashboard/models/fiat/exposure_finished_floor_height.py
+++ b/src/delftdashboard/models/fiat/exposure_finished_floor_height.py
@@ -104,7 +104,7 @@ def add_to_model(*args):
     # Get the max distance
     max_dist_gfh = app.gui.getvar("fiat", "max_dist_gfh")
 
-    app.active_model.domain.exposure_vm.set_ground_floor_height(
+    app.active_model.domain.exposure_vm.set_finished_floor_height(
         source=source_path,
         attribute_name=attribute_name_gfh,
         method=method_gfh,

--- a/src/delftdashboard/models/fiat/exposure_locations.py
+++ b/src/delftdashboard/models/fiat/exposure_locations.py
@@ -109,7 +109,7 @@ def build_nsi_exposure(*args):
             unique_primary_types,
             unique_secondary_types,
         ) = app.active_model.domain.exposure_vm.set_asset_locations_source(
-            source="NSI", ground_floor_height="NSI", crs=crs
+            source="NSI", finished_floor_height="NSI", crs=crs
         )
         gdf.set_crs(crs, inplace=True)
 

--- a/src/delftdashboard/models/fiat/exposure_start.py
+++ b/src/delftdashboard/models/fiat/exposure_start.py
@@ -102,7 +102,7 @@ def build_nsi_exposure(*args):
             unique_primary_types,
             unique_secondary_types,
         ) = app.active_model.domain.exposure_vm.set_asset_locations_source_and_get_data(
-            source="NSI", ground_floor_height="NSI", crs=crs
+            source="NSI", finished_floor_height="NSI", crs=crs
         )
         gdf.set_crs(crs, inplace=True)
 

--- a/src/delftdashboard/models/fiat/fiat.py
+++ b/src/delftdashboard/models/fiat/fiat.py
@@ -80,9 +80,9 @@ class Model(GenericModel):
             type="circle",
             circle_radius=3,
             legend_position="top-right",
-            legend_title="Ground Floor Height",
+            legend_title="Finished Floor Height",
             line_color="transparent",
-            hover_property="Ground Floor Height",
+            hover_property="Finished Floor Height",
             big_data=True,
             min_zoom=12,
         )
@@ -488,7 +488,7 @@ class Model(GenericModel):
         app.gui.setvar(group, "max_potential_damage_string",[])
         app.gui.setvar(group, "max_potential_damage_value",[])
         app.gui.setvar(group,"view_svi_value", pd.DataFrame)
-        app.gui.setvar(group,"view_exposure_value", pd.DataFrame(columns=["Object ID", "Object Name", "Primary Object Type", "Secondary Object Type", "Max Potential Damage: Structure","Max Potential Damage: Content","Ground Floor Height","Ground Elevation","Extraction Method", "Damage Function: Structure", "Damage Function: Content", "lanes", "Segment Length [m]", "SVI_key_domain", "SVI"]))
+        app.gui.setvar(group,"view_exposure_value", pd.DataFrame(columns=["Object ID", "Object Name", "Primary Object Type", "Secondary Object Type", "Max Potential Damage: Structure","Max Potential Damage: Content","Finished Floor Height","Ground Elevation","Extraction Method", "Damage Function: Structure", "Damage Function: Content", "lanes", "Segment Length [m]", "SVI_key_domain", "SVI"]))
     
     @staticmethod
     def set_dict_inverted(dictionary):
@@ -659,7 +659,7 @@ class Model(GenericModel):
         if type == "asset_height":
              circle_color = [
                 "step",
-                ["get", "Ground Floor Height"],"#000000",
+                ["get", "Finished Floor Height"],"#000000",
                 0.00001, "#FFFFFF",      
                 0.5, "#D6E1F8",      
                 1.0, "#A4C4F2",     

--- a/src/delftdashboard/toolboxes/modelmaker_fiat/modelmaker_fiat.py
+++ b/src/delftdashboard/toolboxes/modelmaker_fiat/modelmaker_fiat.py
@@ -312,7 +312,7 @@ def quick_build(*args):
 
     # BUILDINGS with default settings
     app.active_model.domain.exposure_vm.set_asset_locations_source(
-        source="NSI", ground_floor_height="NSI", crs=crs
+        source="NSI", finished_floor_height="NSI", crs=crs
     )
 
     # Set the damage curves


### PR DESCRIPTION
Kathryn prefers the term Finished Floor Height over Ground Floor Height. 
To be coherent it should be change throughout the whole modelbuilder and gui. 

Question:
I assume this might affect FloodAdapt when referring to or using the model builder data? This should be checked.