### PR TITLE
#238 OSM Roads vertical unit: support user input in meter or feet and conversion from meter to feet

### DIFF
--- a/src/delftdashboard/models/fiat/config/exposure_start.yml
+++ b/src/delftdashboard/models/fiat/config/exposure_start.yml
@@ -30,7 +30,7 @@ element:
   position:
     x: 190
     y: 10
-    width: 170
+    width: 200
     height: 120
   dependency:
     - action: visible
@@ -42,12 +42,23 @@ element:
   element:
   - style: edit
     position:
-      x: 100
+      x: 68
       y: 90
       width: 25
-      height: 18
-    text: "Threshold value (ft)"
+      height: 15
+    text: "Threshold value"
     variable: road_damage_threshold
+  - style: popupmenu
+    position:
+      x: 100
+      y: 90
+      width: 50
+      height: 15
+    variable: vertical_unit
+    option_string:
+      variable: vertical_unit_string
+    option_value:
+      variable: vertical_unit_value
   - style: text
     position:
       x: 10
@@ -81,8 +92,8 @@ element:
     variable: include_primary
   - style: pushbutton
     position:
-      x: 10
-      y: 92
+      x: 180
+      y: 100
       width: 15
       height: 15
     text: "\u2139"

--- a/src/delftdashboard/models/fiat/exposure_start.py
+++ b/src/delftdashboard/models/fiat/exposure_start.py
@@ -190,13 +190,14 @@ def build_nsi_exposure(*args):
     ## ROADS ##
     if app.gui.getvar(model, "include_osm_roads"):
         road_types = get_road_types()
+        vertical_unit = app.gui.getvar("fiat", "vertical_unit")
 
         try:
             dlg = app.gui.window.dialog_wait("\nDownloading OSM data...")
 
             # Get the roads to show in the map
             gdf = app.active_model.domain.exposure_vm.get_osm_roads(
-                road_types=road_types
+                road_types=road_types, vertical_unit = vertical_unit
             )
 
             crs = app.gui.getvar("fiat", "selected_crs")
@@ -204,11 +205,13 @@ def build_nsi_exposure(*args):
 
             app.map.layer["roads"].layer["exposure_lines"].crs = crs
             app.map.layer["roads"].layer["exposure_lines"].set_data(gdf)
+           
+            
 
             # Set the road damage threshold
             road_damage_threshold = app.gui.getvar("fiat", "road_damage_threshold")
             app.active_model.domain.vulnerability_vm.set_road_damage_threshold(
-                road_damage_threshold
+                road_damage_threshold, vertical_unit = vertical_unit
             )
 
             # Show the roads
@@ -287,6 +290,6 @@ def display_asset_locations(*args):
 
 def open_info(*args):
     app.gui.window.dialog_info(
-    text="The threshold value indicates the water level at which a road is not accessible anymore." ,
+    text="The threshold value indicates the water level at which a road is not accessible anymore. If you provide a threshold in meter it will be automatically converted into feet in your output." ,
     title="Threshold value",
     )

--- a/src/delftdashboard/models/fiat/fiat.py
+++ b/src/delftdashboard/models/fiat/fiat.py
@@ -293,7 +293,9 @@ class Model(GenericModel):
         app.gui.setvar(group, "include_secondary", False)
         app.gui.setvar(group, "include_tertiary", False)
         app.gui.setvar(group, "include_all", False)
-
+        app.gui.setvar(group, "vertical_unit", "ft")
+        app.gui.setvar(group, "vertical_unit_string", ["feet", "meter"])
+        app.gui.setvar(group, "vertical_unit_value", ["ft", "m"])
         ## DISPLAY LAYERS ##
         app.gui.setvar(group, "properties_to_display", None)
         app.gui.setvar(group, "show_asset_locations", False)


### PR DESCRIPTION
The user can provide their own threshold in either meter or feet. The default is set to feet. 
If meter is specified as unit it will be converted to feet. 

Changes were done in hydromt-fiat (https://github.com/Deltares/hydromt_fiat/pull/279) and delftdashboard
