### PR TITLE
#70 update values after model built

### DIFF
--- a/src/delftdashboard/models/fiat/exposure_aggregation.py
+++ b/src/delftdashboard/models/fiat/exposure_aggregation.py
@@ -174,7 +174,7 @@ def add_aggregations(*args):
         # If model already create, re-run the model to add additional attributes afterwards without aving to "create model" manually
         if app.active_model.domain.fiat_model.exposure is not None:
             dlg = app.gui.window.dialog_wait("\nAdding additional attributes to your FIAT model...")
-            run_model()
+            update_additional_attributes()
             dlg.close()
 
         app.gui.window.dialog_info(
@@ -238,9 +238,9 @@ def select_additional_attribute(*args):
     else:
         app.map.layer["aggregation"].layer["aggregation_layer"].hide()
 
-def run_model(*args):
+def update_additional_attributes(parameter: str = "Additional Attributes"):
     try:
-        buildings, roads = app.active_model.domain.run_hydromt_fiat()
+        buildings, roads = app.active_model.domain.update_model(parameter)
     except Exception as e:
         app.gui.window.dialog_warning(
             str(e),

--- a/src/delftdashboard/models/fiat/exposure_finished_floor_height.py
+++ b/src/delftdashboard/models/fiat/exposure_finished_floor_height.py
@@ -118,7 +118,7 @@ def add_to_model(*args):
 
     # If model already create, re-run the model to add additional attributes afterwards without aving to "create model" manually
     if app.active_model.domain.fiat_model.exposure is not None:
-        dlg = app.gui.window.dialog_wait("\nAdding additional attributes to your FIAT model...")
+        dlg = app.gui.window.dialog_wait("\nUpdating Finished Floor Height in your FIAT model...")
         update_ground_floor_height()
         dlg.close()
         

--- a/src/delftdashboard/models/fiat/exposure_ground_elevation.py
+++ b/src/delftdashboard/models/fiat/exposure_ground_elevation.py
@@ -93,7 +93,7 @@ def add_to_model(*args):
 
     # If model already create, re-run the model to add additional attributes afterwards without aving to "create model" manually
     if app.active_model.domain.fiat_model.exposure is not None:
-        dlg = app.gui.window.dialog_wait("\nAdding additional attributes to your FIAT model...")
+        dlg = app.gui.window.dialog_wait("\nUpdating Ground Elevation in your FIAT model...")
         update_ground_elevation()
         dlg.close()
 


### PR DESCRIPTION
After a quickbuild or "model from scratch" is built and the user wants to update any parameters,
the model will automatically updated after clicking "add to model" and the user does not create the model another time manually.

Hydromt-fiat PR: https://github.com/Deltares/hydromt_fiat/pull/281

Note:
Max Potential Damages not implemented yet because it might take more effort due to content/structure 