### PR TITLE
GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.yml
@@ -1,17 +1,8 @@
----
 name: Documentation Improvement
 description: Report wrong or missing documentation
 labels: [documentation]
 
 body:
-  - type: checkboxes
-    attributes:
-      label: HydroMT version checks
-      options:
-        - label: >
-            I have checked that the issue still exists on the latest versions of the docs
-            on `main` [here](https://github.com/Deltares/hydromt)
-          required: true
   - type: dropdown
     id: kind
     attributes:
@@ -23,12 +14,14 @@ body:
         - Docs are missing
     validations:
       required: true
+
   - type: textarea
     id: location
     attributes:
       description: >
         If the docs are wrong or unclear please provide the URL of the documentation in question
       label: Location of the documentation
+
   - type: textarea
     id: problem
     attributes:
@@ -37,6 +30,7 @@ body:
       label: Documentation problem
     validations:
       required: true
+      
   - type: textarea
     id: suggested-fix
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,3 @@
----
 name: Feature Request
 description: Suggest an idea/enhancement for this project
 labels: [enhancement, needs refinement]
@@ -43,12 +42,5 @@ body:
     id: context
     attributes:
       description: >
-        Please add any other context about the enhancement here
+        Please add any other context or screenshots about the feature request here. You can select the textbox and 'Paste, drop or click to add files' to attach them to this request.
       label: Additional Context
-
-  - type: file
-    id: attachments
-    attributes:
-      label: Attachments
-      description: >
-        If applicable, attach any screenshots, logs, or code

--- a/.github/ISSUE_TEMPLATE/user_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/user_bug_report.yml
@@ -49,10 +49,12 @@ body:
       label: Desired behaviour
     validations:
       required: true
-  
-  - type: file
-    id: attachments
+
+  - type: textarea
+    id: additional-context
     attributes:
-      label: Attachments
-      description: >
-        If applicable, attach any screenshots, logs, or code
+      label: Additional context
+      description: Please add any other context, logs, code or screenshots about the bug here. You can select the textbox and 'Paste, drop or click to add files' to attach them to this bug report.
+    validations:
+      required: false
+


### PR DESCRIPTION
To enable testers/users to report bugs/missing docs and do feature requests, while keeping our sanity and organization, we provide them with templates that makes it easy for us to see all testing feedback in one place.

To enable these issue templates:
 - someone with **admin rights** needs to go to https://github.com/Deltares-research/DelftDashboard/settings
 - Go to General->Features
 - enable issue templates

