### PR TITLE
fix python version to 3.11 due to the removal of deprecated code in 3…

### DIFF
--- a/src/delftdashboard/env/ddb_floodadapt.yml
+++ b/src/delftdashboard/env/ddb_floodadapt.yml
@@ -6,7 +6,7 @@ channels:
   - pyviz
 
 dependencies:
-  - python>=3.10 
+  - python=3.11 # 3.12 removed deprecated code that a dependency still uses, so we cant use 3.12 yet
   - black  
   - build
   - pyyaml>=5.1.1


### PR DESCRIPTION
….12, which broke our env creation