### PR TITLE
Add your own data

### DIFF
--- a/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/config/bathymetry.yml
+++ b/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/config/bathymetry.yml
@@ -36,6 +36,23 @@ element:
   - style: pushbutton
     position:
       x: 170
+      y: 70
+      width: 20
+      height: 20
+    text: "\u002B"  
+    tooltip: "Add your own dataset to the list of available datasets. \n Note that
+      the dataset should be in the format of a cloud-optimized .tif file."
+    method: add_dataset
+    dependency:
+    - action: visible
+      checkfor: all
+      check:
+      - variable: active_bathymetry_source
+        operator: eq
+        value: "Add your own dataset"
+  - style: pushbutton
+    position:
+      x: 170
       y: 10
       width: 20
       height: 20

--- a/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/modelmaker_sfincs_hmt.py
+++ b/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/modelmaker_sfincs_hmt.py
@@ -110,6 +110,8 @@ class Toolbox(GenericToolbox):
                         source = app.data_catalog[key].meta["source"]
                         if source not in source_names:
                             source_names.append(source)
+            # Add a last entry for the user to add their own bathymetry
+            source_names.append("Add your own dataset")
 
         app.gui.setvar(group, "bathymetry_source_names", source_names)
         app.gui.setvar(group, "active_bathymetry_source", source_names[0])


### PR DESCRIPTION
This enables users to add their own data.

We restrict the users now to only use Cloud-Optimized-Geotiffs. Those geotiffs have built-in overview levels, which allow for fast visualization. I have scripts that add those overviews to "normal" geotiffs, but since it changes the files, I didn't want to include that (yet) as an automated step.

Though the data can be used immediately, the visualization through the "Topography" menu in the top needs some more work. After restarting the GUI however, this should already work.