### PR TITLE
add select button

### DIFF
--- a/src/delftdashboard/models/fiat/create_model_view_model.py
+++ b/src/delftdashboard/models/fiat/create_model_view_model.py
@@ -133,8 +133,9 @@ def toggle_attr_map(*args):
             )
             app.gui.setvar("fiat", "show_attributes", False)
         else:
+            label = ["Select"] + label
             app.gui.setvar("fiat", "aggregation_label_display_string", label)
-            app.gui.setvar("fiat", "aggregation_label_display_value", label)
+            app.gui.setvar("fiat", "aggregation_label_display_value",  label)
             attributes = [app.gui.getvar("fiat", "aggregation_label_display_name")]
             if len(attributes) > 0:
                 app.gui.setvar("fiat", "aggregation_label_display_name", 0)


### PR DESCRIPTION
there were a small issue with the dropdown menu, that if only one attribute added to the model it would not show the layer when clicking on it. Now with "2" options it is possible to select the new added layer. 
It's just a quickfix for the demo