### PR TITLE
added vertical datum to metadata

### DIFF
--- a/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/modelmaker_sfincs_hmt.py
+++ b/src/delftdashboard/toolboxes/modelmaker_sfincs_hmt/modelmaker_sfincs_hmt.py
@@ -42,6 +42,9 @@ class Toolbox(GenericToolbox):
 
         self.setup_dict = {}
 
+        # create "meta" entry in the setup_dict, this is not used in the model but can be used to store additional information
+        self.setup_dict["meta"] = {}
+
         # Set GUI variable
         group = "modelmaker_sfincs_hmt"
 
@@ -128,6 +131,7 @@ class Toolbox(GenericToolbox):
         app.gui.setvar(group, "bathymetry_dataset_names", dataset_names)
         app.gui.setvar(group, "bathymetry_dataset_index", 0)
         app.gui.setvar(group, "selected_bathymetry_dataset_names", [])
+        app.gui.setvar(group, "selected_bathymetry_vdatum", "MSL")
         app.gui.setvar(group, "selected_bathymetry_dataset_index", 0)
         app.gui.setvar(group, "selected_bathymetry_dataset_meta", "")
         app.gui.setvar(group, "selected_bathymetry_dataset_zmin", -99999.0)
@@ -448,6 +452,9 @@ class Toolbox(GenericToolbox):
             return
         self.setup_dict.update({"setup_dep": setup_dep})
 
+        # add the vdatum to the metadata
+        self.setup_dict["meta"]["vertical_datum"] = app.gui.getvar(group, "selected_bathymetry_vdatum")
+        
         # show merged bathymetry on map
         app.map.layer["sfincs_hmt"].layer["bed_levels"].update()
 


### PR DESCRIPTION
For datasets, a vertical_datum should be provided in the metadata of the data_catalog.yml file. For newly added datasets, we check whether it is in the files metadata, otherwise the user should specify it.

Once generating the topobathy of the SFINCS model, we add the vertical datum of the first dataset to the models metadata. This can in the end be found in the "sfincs_build.yaml" file under meta, vertical datum, e.g.:

```
meta:
   vertical_datum: MSL
```

It isn't used for anything, just for keeping track of the vertical reference level after creating the model. Note, this file is only present for models that are built with the FloodAdapt_ModelBuilders ...